### PR TITLE
SideCIとTravisCIの導入

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_script:
 
 script:
   - bundle exec rspec
+
+notifications:
+  slack: techcamp-tokyo-st:O20NFqzyKle2viWwgyMm6yzf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+
+services:
+  - mysql
+
+before_script:
+  - cp config/.travis.database.yml config/database.yml
+  - bin/rails db:setup RAILS_ENV=test
+
+script:
+  - bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TECH::LEAD
 
+[![Build Status](https://travis-ci.org/tc-tokyo-developers/tech-lead.svg?branch=master)](https://travis-ci.org/tc-tokyo-developers/tech-lead)
+
 ***
 ## Description
 

--- a/config/.travis.database.yml
+++ b/config/.travis.database.yml
@@ -1,0 +1,23 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8
+  pool: 5
+  username: root
+  password:
+  socket: /tmp/mysql.sock
+
+development:
+  <<: *default
+  database: tech-lead_development
+
+test:
+  adapter: mysql2
+  encoding: utf8
+  username: travis
+  database: tech-lead_test
+
+production:
+  <<: *default
+  database: tech-lead_production
+  username: tech-lead
+  password: <%= ENV['TECH-LEAD_DATABASE_PASSWORD'] %>

--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,3 @@
+linter:
+  rubocop:
+    config: '.rubocop.yml'


### PR DESCRIPTION
# WHAT
開発効率向上のため、CIサービスを使ってrubocop等を用いたスタイルのチェック、RSpecのテストをGithubに紐付けてできるようにしました。

## SideCI
https://sideci.com
rubocopとかlinterを使って、PRをフックにしてスタイルチェックをしてくれます

## TravisCI
https://travis-ci.org/tc-tokyo-developers/tech-lead
pushとPRをフックにしてコマンドを実行できます
今回は`bundle exec rspec`を実行するようにしています
また、READMEにテストを通ったどうかを表示するバッチを追加しました

# WHY
開発効率向上
