### PR TITLE
.gitignoreにidea下のファイルを指定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # .env
 .env
+
+# rubymineの設定ファイル
+.idea/


### PR DESCRIPTION
# WHAT
.gitignoreにrubymineの設定ファイルである.ideaフォルダ下のファイルを指定.

# WHY
rubymineの設定ファイルをgitに上げないようにするため.
