### PR TITLE
binding_of_caller gemを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ group :development do
 
   # エラー画面変更
   gem 'better_errors'
-  gem 'binding_of_caller'
 
   # 速度計測
   gem 'rack-mini-profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,8 +49,6 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.5.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     bullet (5.7.2)
       activesupport (>= 3.0.0)
@@ -76,7 +74,6 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     database_cleaner (1.6.2)
-    debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.1.5)
     dotenv (2.2.1)
@@ -287,7 +284,6 @@ PLATFORMS
 DEPENDENCIES
   annotate
   better_errors
-  binding_of_caller
   bullet
   byebug
   capybara


### PR DESCRIPTION
# WHAT
binding_of_caller gemを削除

# WHY
rails g コマンドが実行できない問題を解決